### PR TITLE
fl nine - Anpassungen

### DIFF
--- a/fh_fablib/__init__.py
+++ b/fh_fablib/__init__.py
@@ -295,7 +295,7 @@ def nine_vhost(ctx):
             conn,
             f"sudo nine-manage-vhosts virtual-host create {config.domain}"
             " --template=feinheit_cache"
-            " --webroot=/home/www-data/{config.domain}/htdocs",
+            f" --webroot=/home/www-data/{config.domain}/htdocs",
         )
         with conn.cd(config.domain):
             run(conn, "mkdir -f media tmp")

--- a/fh_fablib/__init__.py
+++ b/fh_fablib/__init__.py
@@ -1,3 +1,4 @@
+import invoke
 import io
 import os
 import random
@@ -180,7 +181,10 @@ def _srv_env(conn, path):
 
 
 def _nine_has_manage_databases(conn):
-    return bool(run(conn, "which nine-manage-databases").stdout.strip())
+    try:
+        return bool(run(conn, "which nine-manage-databases").stdout.strip())
+    except invoke.exceptions.UnexpectedExit:
+        return False
 
 
 @task

--- a/fh_fablib/__init__.py
+++ b/fh_fablib/__init__.py
@@ -442,7 +442,7 @@ def nine_disable(ctx):
 @task
 def nine_checkout(ctx):
     """Checkout the repository on the server"""
-    repo = run(ctx, "git config remote.origin.url", hide=True).stdout
+    repo = run(ctx, "git config remote.origin.url", hide=True).stdout.strip()
     with Connection(config.host) as conn:
         run(conn, f"git clone {repo} {config.domain} -b {config.branch}")
 

--- a/fh_fablib/__init__.py
+++ b/fh_fablib/__init__.py
@@ -1,4 +1,3 @@
-import invoke
 import io
 import os
 import random
@@ -181,10 +180,7 @@ def _srv_env(conn, path):
 
 
 def _nine_has_manage_databases(conn):
-    try:
-        return bool(run(conn, "which nine-manage-databases").stdout.strip())
-    except invoke.exceptions.UnexpectedExit:
-        return False
+    return bool(run(conn, "which nine-manage-databases", warn=True).stdout.strip())
 
 
 @task

--- a/fh_fablib/__init__.py
+++ b/fh_fablib/__init__.py
@@ -298,7 +298,7 @@ def nine_vhost(ctx):
             f" --webroot=/home/www-data/{config.domain}/htdocs",
         )
         with conn.cd(config.domain):
-            run(conn, "mkdir -f media tmp")
+            run(conn, "mkdir -p media tmp")
 
 
 @task(auto_shortflags=False, help={"include-www": "Include the www. subdomain"})


### PR DESCRIPTION
Das sind die Änderungen die  es bei mir gebraucht hat. _nine_has_manage_databases hat bei mir immer mit dieser Exception gecrasht. Und mkdir -f scheint es nicht zu geben? Hab ich auch in meiner lokalen Version nicht. Aber -p sollte ja (hier) den gleichen Effekt haben.

Etwas das ich hier nicht drin habe: Bei mir funktioniert keiner der Commands mit psql. Weil User/PW nicht im env sind. Ich habe jetzt jeweils immer vor dem Command noch .profile gesourced, aber kann mir fast nicht vorstellen dass das so nötig ist? Das hat ja offensichtlich auch schon funktioniert.