### PR TITLE
Yarn Files von pre-commit ausschliessen

### DIFF
--- a/fh_fablib/pre-commit-defaults.yaml
+++ b/fh_fablib/pre-commit-defaults.yaml
@@ -1,3 +1,4 @@
+exclude: ".yarn/|yarn.lock"
 repos:
     - repo: https://github.com/pre-commit/pre-commit-hooks
       rev: v4.0.1


### PR DESCRIPTION
Beim LMVZ musste ich alle von Yarn generierten Files vom pre-commit ausschliessen, weil das Lock File und das Release File zu gross werden.

Ich denke dies macht ja für die meisten Projekte sinn.

Was meint ihr? @matthiask @yoshson 

