### PR TITLE
JS, CSS und SCSS Dateien können auch in anderen Verzeichnissen sein

### DIFF
--- a/fh_fablib/__init__.py
+++ b/fh_fablib/__init__.py
@@ -168,20 +168,10 @@ def hook(ctx):
     """
     Add default pre-commit configuration and install hook running coding style checks
     """
-    # shutil.copy(
-    #     Path(__file__).parent / "pre-commit-defaults.yaml",
-    #     config.base / ".pre-commit-config.yaml"
-    # )
-
-    defaults = Path(__file__).parent / "pre-commit-defaults.yaml"
-    pre_commit_config = config.base / ".pre-commit-config.yaml"
-    pre_commit_config.write_text(
-        defaults.read_text().replace(
-            "###FRONTEND_STATIC_PATTERN###",
-            f"{config.app}/static/.*$"
-        )
+    shutil.copy(
+        Path(__file__).parent / "pre-commit-defaults.yaml",
+        config.base / ".pre-commit-config.yaml",
     )
-
     run(ctx, "pre-commit install -f")
 
 

--- a/fh_fablib/pre-commit-defaults.yaml
+++ b/fh_fablib/pre-commit-defaults.yaml
@@ -54,7 +54,7 @@ repos:
       rev: v8.3.0
       hooks:
           - id: eslint
-            types_or: [css, javascript, scss]
+            types_or: [javascript]
             additional_dependencies:
                 - eslint@8.3.0
                 - eslint-config-prettier@8.3.0

--- a/fh_fablib/pre-commit-defaults.yaml
+++ b/fh_fablib/pre-commit-defaults.yaml
@@ -49,13 +49,12 @@ repos:
       hooks:
           - id: prettier
             args: [--list-different, --no-semi]
-            files: "###FRONTEND_STATIC_PATTERN###"
             types_or: [css, javascript, scss]
     - repo: https://github.com/pre-commit/mirrors-eslint
       rev: v8.3.0
       hooks:
           - id: eslint
-            files: "###FRONTEND_STATIC_PATTERN###"
+            types_or: [css, javascript, scss]
             additional_dependencies:
                 - eslint@8.3.0
                 - eslint-config-prettier@8.3.0


### PR DESCRIPTION
Ich habe bei Workbench gute Erfahrungen gemacht ohne `files`, nur mit `types_or`. Letzteres ist evtl. auch nicht notwendig, aber schadet vermutlich kaum.

(JSON, YAML etc. könnte evtl. auch noch prettified werden.)