### PR TITLE
env/ prefix for remotes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,10 @@ Change log
 Next version
 ~~~~~~~~~~~~
 
+- Added a ``env/`` prefix to environment remotes to avoid ambiguous arguments
+  to git when checking out etc..
+
+
 1.0.20250408
 ~~~~~~~~~~~~
 

--- a/fh_fablib/__init__.py
+++ b/fh_fablib/__init__.py
@@ -826,11 +826,11 @@ def fetch(ctx):
     """Ensure a remote exists for the server and fetch"""
     run_local(
         ctx,
-        f"git remote add {config.remote} {config.host}:{config.domain}",
+        f"git remote add env/{config.remote} {config.host}:{config.domain}",
         warn=True,
         hide=True,
     )
-    run_local(ctx, f"git fetch {config.remote}")
+    run_local(ctx, f"git fetch env/{config.remote}")
 
 
 def _check_branch(ctx):


### PR DESCRIPTION
Das verhindert die immer gleiche Fehlermeldung wegen "ambiguous name 'production'".