### PR TITLE
ignore files in dist folders

### DIFF
--- a/fh_fablib/dotfiles/biome.json
+++ b/fh_fablib/dotfiles/biome.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.1.1/schema.json",
+  "files": {
+    "includes": ["!**/dist/**"]
+  },
   "formatter": {
     "enabled": true,
     "useEditorconfig": true


### PR DESCRIPTION
Ich möchte gebundelte Dateien z.B. im CMS einbinden, aber keinen linter und formater auslösen.