### PR TITLE
always include jsi18n globals

### DIFF
--- a/fh_fablib/dotfiles/biome.json
+++ b/fh_fablib/dotfiles/biome.json
@@ -69,7 +69,7 @@
     "formatter": {
       "semicolons": "asNeeded"
     },
-    "globals": []
+    "globals": ["gettext", "ngettext", "interpolate"]
   },
   "json": {
     "formatter": {


### PR DESCRIPTION
Ich finde wir können das immer integrieren. Wenn man js18n nicht nutzt, gibt's im schlimmsten Fall einen Konsolenerror.