### PR TITLE
ignore mutable defaults in classes

### DIFF
--- a/fh_fablib/dotfiles/pyproject.toml
+++ b/fh_fablib/dotfiles/pyproject.toml
@@ -69,6 +69,8 @@ lint.extend-ignore = [
   "E501",
   # Percent-formatting is fine
   "UP031",
+  # Allow mutable defaults for classes
+  "RUF012",
 ]
 lint.per-file-ignores."*/migrat*/*" = [
   # Allow using PascalCase model names in migrations


### PR DESCRIPTION
Mir kreidet es das seit neuestem immer an. z.B. wenn ich Meta-Klassen definiere. Finde ich lästig, oder übersehe ich da was?